### PR TITLE
Update link to the Algolia plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See the [Official Plugins Page @ Jekyll Docs](http://jekyllrb.com/docs/plugins) 
 
 
 ## Search
-- [**Algolia**](https://github.com/algolia/algoliasearch-jekyll) ★103 (gem: [algoliasearch-jekyll](https://rubygems.org/gems/algoliasearch-jekyll/versions/0.8.0))  --  Jekyll plugin to automatically index your Jekyll posts and pages into an Algolia index.
+- [**Algolia**](https://github.com/algolia/jekyll-algolia) ★30 (gem: [jekyll-algolia](https://rubygems.org/gems/jekyll-algolia/))  --  Add fast and relevant search to your Jekyll site using the Algolia API.
 
 <!-- add search gems here -->
 


### PR DESCRIPTION
The Algolia plugin has been renamed and revamped into a newer version. Many bugs were fixed, and it is now compatible with Jekyll 3.