### PR TITLE
Adds Jekyll Github Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ See the [Official Plugins Page @ Jekyll Docs](http://jekyllrb.com/docs/plugins) 
 - [**PlantUML**](https://github.com/yegor256/jekyll-plantuml) ★9 (gem: [jekyll-plantuml](https://rubygems.org/gems/jekyll-plantuml)) -- Tag that renders UML diagrams using [PlantUML](http://plantuml.com/).
 - [**Jekyll oEmbed**](https://github.com/18F/jekyll-oembed) (gem: [jekyll_oembed](https://rubygems.org/gems/jekyll_oembed)) -- The tag version of [ruby-oembed](https://github.com/ruby-oembed/ruby-oembed), letting you easily get embeddable HTML representations of supported web pages, based on their URLs.
 - [**Jekyll PDF Embed**](https://github.com/MihajloNesic/jekyll-pdf-embed) ★3 (gem: [jekyll-pdf-embed](https://rubygems.org/gems/jekyll-pdf-embed)) - Plugin for embedding PDF files to any page or post
+- [**Jekyll Github Chart**](https://github.com/kinduff/jekyll-github-chart) (gem: [jekyll-github-chart](https://rubygems.org/gems/jekyll-github-chart)) - Plugin to generate an SVG of Github contributions data
 
 
 ## Search Engine Optimization (SEO) & Redirects


### PR DESCRIPTION
I created this plugin to add Github's contribution chart in any part of a Jekyll website using a Liquid Tag. I was hoping to have this added to this awesome repo.