### PR TITLE
Add jekyll-responsive-magick plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ See the [Official Plugins Page @ Jekyll Docs](http://jekyllrb.com/docs/plugins) 
 - [**jekyll-imgix**](https://github.com/imgix/jekyll-imgix) ★49 (gem: [jekyll-imgix](https://rubygems.org/gems/jekyll-imgix)) -- Transform, optimize, and intelligently cache your entire image library for fast websites and apps. **Freemium/Commercial**
 - [**jekyll-postfiles**](https://github.com/nhoizey/jekyll-postfiles) ★109 (gem: [jekyll-postfiles](https://rubygems.org/gems/jekyll-postfiles)) -- Ease the management of images (and other files) attached to Markdown blog posts
 - [**jekyll-imgproxy-tag**](https://github.com/jayroh/jekyll-imgproxy-tag) ★0 (gem: [jekyll-imgproxy-tag](https://rubygems.org/gems/jekyll-imgproxy-tag)) -- Generate urls to secure imgproxy images.
+- [**jekyll-responsive-magick**](https://github.com/lawmurray/jekyll-responsive-magick) ★0 (gem: [jekyll-responsive-magick](https://rubygems.org/gems/jekyll-responsive-magick)) -- Responsive images via `srcset`, `width` and `height` filters, automatic image resizing with ImageMagick.
 
 <!-- add a new category for bundled icons / images - why? why not? -->
 


### PR DESCRIPTION
I created the [jekyll-responsive-magick](https://github.com/lawmurray/jekyll-responsive-magick) plugin recently to work with Jekyll 4 with no additional dependencies required. This pull request adds a link to the "Images & Pictures" category here.