### PR TITLE
Add jekyll-react-player plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ flexible resizing, default styling, overridable styling, an optional caption, an
 
 - [**YouTube**](https://github.com/dommmel/jekyll-youtube) ★79 (gem: [jekyll-youtube](https://rubygems.org/gems/jekyll-youtube)) -- a Liquid tag that embeds YouTube videos. The default emded markup is responsive but you can also specify your own by using an include/partial.
 - [**Asciinema**](https://github.com/mnuessler/jekyll-asciinema) ★37 (gem: [jekyll-asciinema](https://rubygems.org/gems/jekyll-asciinema)) -- a tag for embedding asciicasts recorded with asciinema in your Jekyll pages.
+- [**ReactPlayer**](https://github.com/jessp01/jekyll-react-player) (gem: [jekyll-react-player](https://rubygems.org/gems/jekyll-react-player)) -- a tag for embedding react-player supported formats in your Jekyll pages.
 
 
 ## Audios & Podcasts


### PR DESCRIPTION
`react-player` is capable of rendering a player for a variety of formats, including file paths, YouTube, Facebook, Twitch, SoundCloud, Streamable, Vimeo, Wistia, Mixcloud, DailyMotion and Kaltura. 

See full list of supported formats here: https://github.com/jessp01/react-player/#supported-media

Adding this plugin will enable you to embed any supported format with one unified tag, to wit:

```ruby
{% reactplayer https://packman.io/assets/super-zaje.mp4 %}
```

Where `https://packman.io/assets/super-zaje.mp4` can be replaced with any supported format.
