### PR TITLE
Added jekyll-fetch-notion plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ Outputs a string of random hexadecimal characters of any length.
 
 - [**Manager**](https://github.com/ashmaroli/jekyll-manager) ★51 (gem: [jekyll-manager](https://rubygems.org/gems/jekyll-manager)) by Ashwin Maroli -- An administrative framework for Jekyll sites, Jekyll Manager is essentially Jekyll Admin repackaged with some alterations.
 
+- [**Notion Fetch**](https://github.com/seroperson/jekyll-fetch-notion) ★4 (gem: [jekyll-fetch-notion](https://rubygems.org/gems/jekyll-fetch-notion)) -- Makes it easy to manage your website content using Notion (git-based approach).
+
 
 ## Watch & Live Reload
 


### PR DESCRIPTION
This plugin ([jekyll-fetch-notion](https://github.com/seroperson/jekyll-fetch-notion)) introduces the `fetch_notion` command. This command fetches all Notion content as specified by the `_config.yml` file and places it directly into your git repository (to be committed later), respecting the corresponding directory structure.