### PR TITLE
Add FastComments to Tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Organizes the index of a collection into chapters.
 by Mike Slinn &ndash;
 Jekyll tags for HTML &lt;pre/&gt;; copy content button, unselectable text, and incorporating command-line output into documents.
 - [**Jekyll Series Links**](https://github.com/ahalbert/jekyll-series-links), (gem: [jekyll-series-links](https://rubygems.org/search?query=jekyll-series-links)) by Armand Halbert – Liquid tag that allows you to generate a table of contents for multi-part post series.
+- [**FastComments**](https://github.com/FastComments/fastcomments-jekyll) ★0 (gem: [fastcomments-jekyll](https://rubygems.org/gems/fastcomments-jekyll)) by FastComments -- Liquid tags for embedding FastComments live commenting, chat, and review widgets.
 
 
 ## Search Engine Optimization (SEO) & Redirects

--- a/README.md
+++ b/README.md
@@ -237,7 +237,6 @@ Organizes the index of a collection into chapters.
 by Mike Slinn &ndash;
 Jekyll tags for HTML &lt;pre/&gt;; copy content button, unselectable text, and incorporating command-line output into documents.
 - [**Jekyll Series Links**](https://github.com/ahalbert/jekyll-series-links), (gem: [jekyll-series-links](https://rubygems.org/search?query=jekyll-series-links)) by Armand Halbert – Liquid tag that allows you to generate a table of contents for multi-part post series.
-- [**FastComments**](https://github.com/FastComments/fastcomments-jekyll) (gem: [fastcomments-jekyll](https://rubygems.org/gems/fastcomments-jekyll)) by FastComments -- Liquid tags for embedding FastComments live commenting, chat, and review widgets.
 
 
 ## Search Engine Optimization (SEO) & Redirects
@@ -253,6 +252,11 @@ Jekyll tags for HTML &lt;pre/&gt;; copy content button, unselectable text, and i
 ## Analytics
 
 - [**Analytics**](https://github.com/hendrik91/jekyll-analytics) ★191 (gem: [jekyll-analytics](https://rubygems.org/gems/jekyll-analytics)) by Hendrik Schneider -- adds webtracking easily to your site; supports multiple trackers like Google Analytics, Piwik, etc.
+
+
+## Comments
+
+- [**FastComments**](https://github.com/FastComments/fastcomments-jekyll) (gem: [fastcomments-jekyll](https://rubygems.org/gems/fastcomments-jekyll)) by FastComments -- Liquid tags for embedding FastComments live commenting, chat, and review widgets.
 
 
 ## Generators

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Organizes the index of a collection into chapters.
 by Mike Slinn &ndash;
 Jekyll tags for HTML &lt;pre/&gt;; copy content button, unselectable text, and incorporating command-line output into documents.
 - [**Jekyll Series Links**](https://github.com/ahalbert/jekyll-series-links), (gem: [jekyll-series-links](https://rubygems.org/search?query=jekyll-series-links)) by Armand Halbert – Liquid tag that allows you to generate a table of contents for multi-part post series.
-- [**FastComments**](https://github.com/FastComments/fastcomments-jekyll) ★0 (gem: [fastcomments-jekyll](https://rubygems.org/gems/fastcomments-jekyll)) by FastComments -- Liquid tags for embedding FastComments live commenting, chat, and review widgets.
+- [**FastComments**](https://github.com/FastComments/fastcomments-jekyll) (gem: [fastcomments-jekyll](https://rubygems.org/gems/fastcomments-jekyll)) by FastComments -- Liquid tags for embedding FastComments live commenting, chat, and review widgets.
 
 
 ## Search Engine Optimization (SEO) & Redirects


### PR DESCRIPTION
Hello! I created a jekyll plugin for FastComments which we will maintain.

Adds [fastcomments-jekyll](https://github.com/FastComments/fastcomments-jekyll) under a new **Comments** section (placed between Analytics and Generators).

It's a gem-packaged Jekyll plugin that registers Liquid tags for embedding FastComments widgets (live commenting, live chat, collab/image chat, reviews summary, recent comments/discussions, top pages, and user activity feed) into Jekyll sites. Set your tenant id once in `_config.yml`, then drop `{% fastcomments %}` into any layout, post, or page.

- Gem: https://rubygems.org/gems/fastcomments-jekyll
- Docs: https://docs.fastcomments.com/guide-lib-jekyll.html
- Live demo: https://fastcomments.com/commenting-system-for-jekyll/

Happy to fold it into an existing section instead if you'd prefer.
