### PR TITLE
Add Jekyll-Pagefind plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See the [Official Plugins Page @ Jekyll Docs](http://jekyllrb.com/docs/plugins) 
 - [**Searchyll**](https://github.com/omc/searchyll) ★43 (gem: [searchyll](https://rubygems.org/gems/searchyll/)) - Index your Jekyll pages to Elasticsearch, and works with Github pages.
 
 <!-- add search gems here -->
-
+- [**Pagefind**](https://github.com/phothinmg/jekykll-pagefind) ★1 (gem: [jekyll-pagefind](https://rubygems.org/gems/jekyll-pagefind/)) -- Run pagefind binary in jekyll site
 
 ## Feeds & Syndication
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ See the [Official Plugins Page @ Jekyll Docs](http://jekyllrb.com/docs/plugins) 
 
 - [**Algolia**](https://github.com/algolia/jekyll-algolia) ★185 (gem: [jekyll-algolia](https://rubygems.org/gems/jekyll-algolia/))  --  Add fast and relevant search to your Jekyll site using the Algolia API. **Deprecated**
 - [**Searchyll**](https://github.com/omc/searchyll) ★43 (gem: [searchyll](https://rubygems.org/gems/searchyll/)) - Index your Jekyll pages to Elasticsearch, and works with Github pages.
-
-<!-- add search gems here -->
 - [**Pagefind**](https://github.com/phothinmg/jekykll-pagefind) ★1 (gem: [jekyll-pagefind](https://rubygems.org/gems/jekyll-pagefind/)) -- Run pagefind binary in jekyll site
+<!-- add search gems here -->
+
 
 ## Feeds & Syndication
 


### PR DESCRIPTION
### Add `jekyll-pagefind` plugin

**Search plugin updates:**

* Added `[**Pagefind**](https://github.com/phothinmg/jekykll-pagefind)` to the list of search plugins, providing an option to run the Pagefind binary in a Jekyll site.

**Plugin Info:**

* Github: <https://github.com/phothinmg/jekykll-pagefind>
* RubyGems: <https://rubygems.org/gems/jekyll-pagefind>
* Docs: <https://github.com/phothinmg/jekykll-pagefind/blob/main/README.md>